### PR TITLE
Fix Kona and Niro modules; remove Ioniq workaround

### DIFF
--- a/cars/KONA_EV.py
+++ b/cars/KONA_EV.py
@@ -1,7 +1,7 @@
 from car import *
 
-b220101 = bytes.fromhex(hex(b220101)[2:])
-b220105 = bytes.fromhex(hex(b220105)[2:])
+b220101 = bytes.fromhex(hex(0x220101)[2:])
+b220105 = bytes.fromhex(hex(0x220105)[2:])
 
 class KONA_EV(Car):
 

--- a/cars/NIRO_EV.py
+++ b/cars/NIRO_EV.py
@@ -1,7 +1,7 @@
 from car import *
 
-b220101 = bytes.fromhex(hex(b220101)[2:])
-b220105 = bytes.fromhex(hex(b220105)[2:])
+b220101 = bytes.fromhex(hex(0x220101)[2:])
+b220105 = bytes.fromhex(hex(0x220105)[2:])
 
 class NIRO_EV(Car):
 


### PR DESCRIPTION
- Fix an oversight on Kona and Niro
- Remove a workaround for Ioniq; the problem was properly fixed by directly addressing the controll units