### PR TITLE
Guard against the posibility that RPi module cannot be imported

### DIFF
--- a/dongles/AtBaseDongle.py
+++ b/dongles/AtBaseDongle.py
@@ -3,7 +3,10 @@ import serial
 from threading import Lock
 from time import sleep
 import math
-import RPi.GPIO as GPIO
+try:
+    import RPi.GPIO as GPIO
+except RuntimeError:
+    pass
 import logging
 
 class ATBASE:

--- a/dongles/SocketCAN.py
+++ b/dongles/SocketCAN.py
@@ -5,7 +5,10 @@ import math
 from pyroute2 import IPRoute
 from time import sleep
 import logging
-import RPi.GPIO as GPIO
+try:
+    import RPi.GPIO as GPIO
+except RuntimeError:
+    pass
 
 CANFMT = "<IB3x8s"
 


### PR DESCRIPTION
(Because we're not running on a Raspberry Pi). This is fine so long as we don't try to use the watchdog.