### PR TITLE
Maybe fix spurious charge abort notifications

### DIFF
--- a/evnotify.py
+++ b/evnotify.py
@@ -103,7 +103,9 @@ class EVNotify:
                 if ((now - last_charging > ABORT_NOTIFICATION_INTERVAL and
                      charging_start_soc > 0 and 0 < last_charging_soc < soc_threshold and
                      abort_notification is ARMED) or abort_notification is FAILED):
-                    log.info("Aborted charge detected, send abort notification")
+                    log.info("Aborted charge detected, send abort notification now-last_charging(%i) charging_start_soc(%i) last_charging_soc(%i) soc_threshold(%i) abort_notification(%i)",
+                             now - last_charging, charging_start_soc, last_charging_soc,
+                             soc_threshold, abort_notification)
                     try:
                         evn.sendNotification(True)
                         abort_notification = SENT

--- a/evnotify.py
+++ b/evnotify.py
@@ -79,6 +79,8 @@ class EVNotify:
         last_charging = time()
         last_charging_soc = 0
         last_evn_settings_poll = 0
+        is_charging = 0
+        is_connected = 0
         settings = None
         soc_notification = ARMED
         soc_threshold = self._config.get('soc_threshold', 100)

--- a/evnotify.py
+++ b/evnotify.py
@@ -145,13 +145,16 @@ class EVNotify:
             try:
                 if (data['SOC_DISPLAY'] is not None or
                         data['SOC_BMS'] is not None):
-                    evn.setSOC(data['SOC_DISPLAY'], data['SOC_BMS'])
 
                     current_soc = data['SOC_DISPLAY'] or data['SOC_BMS']
-
                     is_charging = bool(data['charging'])
                     is_connected = bool(data['normalChargePort'] or data['rapidChargePort'])
 
+                    if is_charging:
+                        last_charging = now
+                        last_charging_soc = current_soc
+
+                    evn.setSOC(data['SOC_DISPLAY'], data['SOC_BMS'])
                     extended_data = {a: round(data[a], EXTENDED_FIELDS[a])
                                      for a in EXTENDED_FIELDS if data[a] is not None}
                     log.debug(extended_data)
@@ -196,10 +199,6 @@ class EVNotify:
                     except EVNotifyAPI.CommunicationError as err:
                         log.info("Communication Error: %s", err)
                         soc_notification = FAILED
-
-                if is_charging:
-                    last_charging = now
-                    last_charging_soc = current_soc
 
             except EVNotifyAPI.CommunicationError as err:
                 log.info("Communication Error: %s", err)


### PR DESCRIPTION
Needs more testing!
Abort notification basically works by tracking when the car was last charging. When there is a problem in communication to the evnotify backend this doesn't get updated which in turn triggers the notification. This should fix it, more testing is needed, though!

Also allows the generic isotp-parser to work when the length of the data reported by the car is not initially known. This needs to be enabled by the car module, so this code does nothing as long as it is not requested.